### PR TITLE
Fix code scanning alert no. 5: Incomplete regular expression for hostnames

### DIFF
--- a/frontend/src/metabase/admin/people/containers/AdminPeopleApp.unit.spec.tsx
+++ b/frontend/src/metabase/admin/people/containers/AdminPeopleApp.unit.spec.tsx
@@ -48,7 +48,7 @@ describe("AdminPeopleApp", () => {
       expect(link).toBeInTheDocument();
       expect(link).toHaveAttribute(
         "href",
-        expect.stringMatching(/^https:\/\/www.metabase.com\/upgrade/),
+        expect.stringMatching(/^https:\/\/www\.metabase\.com\/upgrade/),
       );
     });
     it("should not be visible with less than 50 users", () => {


### PR DESCRIPTION
Fixes [https://github.com/viridios-ai/metabase/security/code-scanning/5](https://github.com/viridios-ai/metabase/security/code-scanning/5)

To fix the problem, we need to escape the `.` character in the regular expression to ensure it matches a literal dot rather than any character. This can be done by replacing `.` with `\.` in the regular expression. Specifically, we need to update the regular expression on line 51 to `^https:\/\/www\.metabase\.com\/upgrade`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
